### PR TITLE
Extend GPU activation support

### DIFF
--- a/src/bnn/BackPropagationNeuralNetwork.cs
+++ b/src/bnn/BackPropagationNeuralNetwork.cs
@@ -15,6 +15,7 @@ public sealed class BackPropagationNeuralNetwork
     private readonly bool _useGpu;
     private Func<double, double> _activationDerivative;
     private Func<double, double> _activationFunction;
+    private ActivationKind _activationKind;
     private double[] _hiddenLayer;
 
     public BackPropagationNeuralNetwork(int inputs = 0,
@@ -36,6 +37,7 @@ public sealed class BackPropagationNeuralNetwork
 
         _activationFunction = activation;
         _activationDerivative = activationDerivative;
+        _activationKind = ActivationKind.Sigmoid;
     }
 
     public BackPropagationNeuralNetwork(Weights weights, bool useGpu = false) : this(weights.Input, weights.Hidden, weights.Output, useGpu)
@@ -85,7 +87,7 @@ public sealed class BackPropagationNeuralNetwork
                                                                initialErrors,
                                                                outputLayer,
                                                                trainingRate,
-                                                               _activationDerivative);
+                                                               _activationKind);
 
                     GpuBackpropagation.UpdateWeightsGpu(_initialCluster, input, initialErrors);
 
@@ -137,10 +139,13 @@ public sealed class BackPropagationNeuralNetwork
         return Pass(inputLayer);
     }
 
-    public void SetActivationFunction(Func<double, double> activation, Func<double, double> activationDerivative)
+    public void SetActivationFunction(Func<double, double> activation,
+                                      Func<double, double> activationDerivative,
+                                      ActivationKind activationKind)
     {
         _activationFunction = activation;
         _activationDerivative = activationDerivative;
+        _activationKind = activationKind;
     }
 
     private static void UpdateWeights(double[,] cluster, double[] inputs, double[] errors)
@@ -166,7 +171,7 @@ public sealed class BackPropagationNeuralNetwork
     {
         if (_useGpu)
         {
-            return GpuBackpropagation.CalculateLayerOutputGpu(inputs, cluster, _activationFunction);
+            return GpuBackpropagation.CalculateLayerOutputGpu(inputs, cluster, _activationKind);
         }
 
         double[] outputs = new double[cluster.GetLength(0)];

--- a/src/bnn/Commands/PredictCommand.cs
+++ b/src/bnn/Commands/PredictCommand.cs
@@ -4,6 +4,7 @@ using System.Text;
 using bnn.Activation;
 using bnn.Data;
 using bnn.Extensions;
+using bnn.Gpu;
 using bnn.Options;
 using bnn.Serialization;
 using bnn.Utils;
@@ -123,7 +124,7 @@ public static class PredictCommand
             BackPropagationNeuralNetwork network = new(weights, options.UseGpu);
 
             (Func<double, double> activation, Func<double, double> activationDerivative) = options.Activation.ToLowerInvariant() switch
-                                                                                           {
+           {
                                                                                                "sigmoid" => ActivationFunctions.Sigmoid,
                                                                                                "relu" => ActivationFunctions.ReLu,
                                                                                                "tanh" => ActivationFunctions.Tanh,
@@ -133,9 +134,10 @@ public static class PredictCommand
                                                                                                { } unknown =>
                                                                                                    throw new
                                                                                                        ArgumentException($"Unsupported activation function: {unknown}")
-                                                                                           };
+           };
+            ActivationKind kind = ActivationFunctionsGpu.ParseKind(options.Activation);
 
-            network.SetActivationFunction(activation, activationDerivative);
+            network.SetActivationFunction(activation, activationDerivative, kind);
 
             Console.WriteLine();
             ConsoleOutput.PrintInfo("Generating predictions...");

--- a/src/bnn/Commands/TrainNetworkCommand.cs
+++ b/src/bnn/Commands/TrainNetworkCommand.cs
@@ -2,6 +2,7 @@
 using System.CommandLine.NamingConventionBinder;
 using bnn.Activation;
 using bnn.Data;
+using bnn.Gpu;
 using bnn.Options;
 using bnn.Serialization;
 using bnn.Services;
@@ -198,11 +199,14 @@ internal static class TrainNetworkCommand
 
             INeuralNetworkTrainerService trainer = host.Services.GetRequiredService<INeuralNetworkTrainerService>();
 
+            ActivationKind kind = ActivationFunctionsGpu.ParseKind(options.Activation);
+
             TrainingReport trainingReport = await trainer.TrainAsync(options,
                                                                      trainingData,
                                                                      initialWeights,
                                                                      activation,
-                                                                     activationDerivative);
+                                                                     activationDerivative,
+                                                                     kind);
 
             Console.WriteLine();
 

--- a/src/bnn/Gpu/ActivationFunctionsGpu.cs
+++ b/src/bnn/Gpu/ActivationFunctionsGpu.cs
@@ -1,0 +1,80 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+public enum ActivationKind
+{
+    Sigmoid,
+    Relu,
+    Tanh,
+    SignedRoot,
+    CubeRoot
+}
+
+public static class ActivationFunctionsGpu
+{
+    public static ActivationKind ParseKind(string name)
+    {
+        return name.ToLowerInvariant() switch
+        {
+            "sigmoid" => ActivationKind.Sigmoid,
+            "relu" => ActivationKind.Relu,
+            "tanh" => ActivationKind.Tanh,
+            "signedroot" => ActivationKind.SignedRoot,
+            "cuberoot" => ActivationKind.CubeRoot,
+            _ => ActivationKind.Sigmoid
+        };
+    }
+
+    public static void ApplyActivation(ReadWriteBuffer<float> buffer, int length, ActivationKind kind)
+    {
+        GraphicsDevice device = GraphicsDevice.GetDefault();
+
+        switch (kind)
+        {
+            case ActivationKind.Sigmoid:
+                device.For(length, new SigmoidKernel(buffer));
+                break;
+            case ActivationKind.Relu:
+                device.For(length, new ReluKernel(buffer));
+                break;
+            case ActivationKind.Tanh:
+                device.For(length, new TanhKernel(buffer));
+                break;
+            case ActivationKind.SignedRoot:
+                device.For(length, new SignedRootKernel(buffer));
+                break;
+            case ActivationKind.CubeRoot:
+                device.For(length, new CubeRootKernel(buffer));
+                break;
+        }
+    }
+
+    public static float[] Derivative(float[] outputs, ActivationKind kind)
+    {
+        using ReadOnlyBuffer<float> outputBuffer = GraphicsDevice.GetDefault().AllocateReadOnlyBuffer(outputs);
+        using ReadWriteBuffer<float> derivativeBuffer = GraphicsDevice.GetDefault().AllocateReadWriteBuffer<float>(outputs.Length);
+        GraphicsDevice device = GraphicsDevice.GetDefault();
+
+        switch (kind)
+        {
+            case ActivationKind.Sigmoid:
+                device.For(outputs.Length, new SigmoidDerivativeKernel(outputBuffer, derivativeBuffer));
+                break;
+            case ActivationKind.Relu:
+                device.For(outputs.Length, new ReluDerivativeKernel(outputBuffer, derivativeBuffer));
+                break;
+            case ActivationKind.Tanh:
+                device.For(outputs.Length, new TanhDerivativeKernel(outputBuffer, derivativeBuffer));
+                break;
+            case ActivationKind.SignedRoot:
+                device.For(outputs.Length, new SignedRootDerivativeKernel(outputBuffer, derivativeBuffer));
+                break;
+            case ActivationKind.CubeRoot:
+                device.For(outputs.Length, new CubeRootDerivativeKernel(outputBuffer, derivativeBuffer));
+                break;
+        }
+
+        return derivativeBuffer.ToArray();
+    }
+}

--- a/src/bnn/Gpu/CubeRootDerivativeKernel.cs
+++ b/src/bnn/Gpu/CubeRootDerivativeKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct CubeRootDerivativeKernel(ReadOnlyBuffer<float> outputs, ReadWriteBuffer<float> derivatives) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float y = outputs[i];
+        derivatives[i] = y == 0f ? 0f : 1f / (3f * y * y);
+    }
+}

--- a/src/bnn/Gpu/CubeRootKernel.cs
+++ b/src/bnn/Gpu/CubeRootKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct CubeRootKernel(ReadWriteBuffer<float> data) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float x = data[i];
+        data[i] = Hlsl.Sign(x) * Hlsl.Pow(Hlsl.Abs(x), 1f / 3f);
+    }
+}

--- a/src/bnn/Gpu/FinalErrorsKernel.cs
+++ b/src/bnn/Gpu/FinalErrorsKernel.cs
@@ -1,0 +1,17 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct FinalErrorsKernel(
+    ReadWriteBuffer<float> finalErrors,
+    ReadOnlyBuffer<float> outputDerivatives,
+    float trainingRate) : IComputeShader
+{
+    public void Execute()
+    {
+        int o = ThreadIds.X;
+        finalErrors[o] *= trainingRate * outputDerivatives[o];
+    }
+}

--- a/src/bnn/Gpu/InitialErrorsKernel.cs
+++ b/src/bnn/Gpu/InitialErrorsKernel.cs
@@ -1,0 +1,28 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct InitialErrorsKernel(
+    ReadOnlyBuffer<float> cluster,
+    ReadOnlyBuffer<float> finalErrors,
+    ReadOnlyBuffer<float> hiddenDerivatives,
+    ReadWriteBuffer<float> initialErrors,
+    float trainingRate,
+    int outputs,
+    int stride) : IComputeShader
+{
+    public void Execute()
+    {
+        int h = ThreadIds.X;
+        float sum = 0f;
+
+        for (int o = 0; o < outputs; o++)
+        {
+            sum += finalErrors[o] * cluster[o * stride + h];
+        }
+
+        initialErrors[h] = sum * trainingRate * hiddenDerivatives[h];
+    }
+}

--- a/src/bnn/Gpu/ReluDerivativeKernel.cs
+++ b/src/bnn/Gpu/ReluDerivativeKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct ReluDerivativeKernel(ReadOnlyBuffer<float> outputs, ReadWriteBuffer<float> derivatives) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float y = outputs[i];
+        derivatives[i] = y > 0f ? 1f : 0f;
+    }
+}

--- a/src/bnn/Gpu/ReluKernel.cs
+++ b/src/bnn/Gpu/ReluKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct ReluKernel(ReadWriteBuffer<float> data) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float x = data[i];
+        data[i] = Hlsl.Max(0f, x);
+    }
+}

--- a/src/bnn/Gpu/SigmoidDerivativeKernel.cs
+++ b/src/bnn/Gpu/SigmoidDerivativeKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct SigmoidDerivativeKernel(ReadOnlyBuffer<float> outputs, ReadWriteBuffer<float> derivatives) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float y = outputs[i];
+        derivatives[i] = y * (1f - y);
+    }
+}

--- a/src/bnn/Gpu/SigmoidKernel.cs
+++ b/src/bnn/Gpu/SigmoidKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct SigmoidKernel(ReadWriteBuffer<float> data) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float x = data[i];
+        data[i] = 1f / (1f + Hlsl.Exp(-x));
+    }
+}

--- a/src/bnn/Gpu/SignedRootDerivativeKernel.cs
+++ b/src/bnn/Gpu/SignedRootDerivativeKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct SignedRootDerivativeKernel(ReadOnlyBuffer<float> outputs, ReadWriteBuffer<float> derivatives) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float y = outputs[i];
+        derivatives[i] = y == 0f ? 0f : 1f / (2f * y);
+    }
+}

--- a/src/bnn/Gpu/SignedRootKernel.cs
+++ b/src/bnn/Gpu/SignedRootKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct SignedRootKernel(ReadWriteBuffer<float> data) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float x = data[i];
+        data[i] = Hlsl.Sign(x) * Hlsl.Sqrt(Hlsl.Abs(x));
+    }
+}

--- a/src/bnn/Gpu/TanhDerivativeKernel.cs
+++ b/src/bnn/Gpu/TanhDerivativeKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct TanhDerivativeKernel(ReadOnlyBuffer<float> outputs, ReadWriteBuffer<float> derivatives) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float y = outputs[i];
+        derivatives[i] = 1f - y * y;
+    }
+}

--- a/src/bnn/Gpu/TanhKernel.cs
+++ b/src/bnn/Gpu/TanhKernel.cs
@@ -1,0 +1,15 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct TanhKernel(ReadWriteBuffer<float> data) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float x = data[i];
+        data[i] = Hlsl.Tanh(x);
+    }
+}

--- a/src/bnn/Gpu/UpdateWeightsKernel.cs
+++ b/src/bnn/Gpu/UpdateWeightsKernel.cs
@@ -1,0 +1,26 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct UpdateWeightsKernel(
+    ReadWriteBuffer<float> cluster,
+    ReadOnlyBuffer<float> inputs,
+    ReadOnlyBuffer<float> errors,
+    int inputSize,
+    int stride) : IComputeShader
+{
+    public void Execute()
+    {
+        int r = ThreadIds.X;
+        float err = errors[r];
+
+        for (int c = 0; c < inputSize; c++)
+        {
+            cluster[r * stride + c] += err * inputs[c];
+        }
+
+        cluster[r * stride + inputSize] += err;
+    }
+}

--- a/src/bnn/Services/INeuronalNetworkTrainerService.cs
+++ b/src/bnn/Services/INeuronalNetworkTrainerService.cs
@@ -1,4 +1,5 @@
 ﻿using bnn.Data;
+using bnn.Gpu;
 using bnn.Options;
 
 namespace bnn.Services;
@@ -8,7 +9,8 @@ public interface INeuralNetworkTrainerService
     Task<TrainingReport> TrainAsync(TrainOptions options,
                                     TrainingData trainingData,
                                     Weights initialWeights,
-                                    Func<double, double> activation,
-                                    Func<double, double> activationDerivative,
-                                    CancellationToken cancellationToken = default);
+                                     Func<double, double> activation,
+                                     Func<double, double> activationDerivative,
+                                     ActivationKind activationKind,
+                                     CancellationToken cancellationToken = default);
 }

--- a/src/bnn/Services/NeuronalNetworkTrainerService.cs
+++ b/src/bnn/Services/NeuronalNetworkTrainerService.cs
@@ -1,5 +1,6 @@
 ﻿using bnn.Data;
 using bnn.Options;
+using bnn.Gpu;
 
 namespace bnn.Services;
 
@@ -12,11 +13,12 @@ internal sealed class NeuralNetworkTrainerService : INeuralNetworkTrainerService
                                                  Weights initialWeights,
                                                  Func<double, double> activation,
                                                  Func<double, double> activationDerivative,
+                                                 ActivationKind activationKind,
                                                  CancellationToken cancellationToken = default)
     {
         BackPropagationNeuralNetwork network = new(initialWeights, options.UseGpu);
 
-        network.SetActivationFunction(activation, activationDerivative);
+        network.SetActivationFunction(activation, activationDerivative, activationKind);
 
         TrainingReport trainingReport = network.BackPropagate(trainingData, options.LearningRate, options.MaxEpochs, options.Seed);
 


### PR DESCRIPTION
## Summary
- add GPU kernels for all activation functions and their derivatives
- compute activations and error derivatives on the GPU
- update backpropagation to use `ActivationKind`
- adjust CLI and services to pass the activation type

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b68da0288333a8b36aaa51add8b4