### PR TITLE
Add persistent GPU buffers

### DIFF
--- a/src/bnn/Commands/PredictCommand.cs
+++ b/src/bnn/Commands/PredictCommand.cs
@@ -5,6 +5,7 @@ using bnn.Activation;
 using bnn.Data;
 using bnn.Extensions;
 using bnn.Gpu;
+using bnn;
 using bnn.Options;
 using bnn.Serialization;
 using bnn.Utils;
@@ -121,7 +122,9 @@ public static class PredictCommand
 
             Weights weights = WeightsSerializer.DeserializeFromFile(options.WeightsFile);
 
-            BackPropagationNeuralNetwork network = new(weights, options.UseGpu);
+            IBackPropagationNeuralNetwork network = options.UseGpu
+                ? new BackPropagationNeuralNetworkGpu(weights)
+                : new BackPropagationNeuralNetwork(weights);
 
             (Func<double, double> activation, Func<double, double> activationDerivative) = options.Activation.ToLowerInvariant() switch
            {

--- a/src/bnn/Gpu/ActivationFunctionsGpu.cs
+++ b/src/bnn/Gpu/ActivationFunctionsGpu.cs
@@ -50,10 +50,8 @@ public static class ActivationFunctionsGpu
         }
     }
 
-    public static float[] Derivative(float[] outputs, ActivationKind kind)
+    public static void Derivative(ReadOnlyBuffer<float> outputs, ReadWriteBuffer<float> derivativeBuffer, ActivationKind kind)
     {
-        using ReadOnlyBuffer<float> outputBuffer = GraphicsDevice.GetDefault().AllocateReadOnlyBuffer(outputs);
-        using ReadWriteBuffer<float> derivativeBuffer = GraphicsDevice.GetDefault().AllocateReadWriteBuffer<float>(outputs.Length);
         GraphicsDevice device = GraphicsDevice.GetDefault();
 
         switch (kind)
@@ -74,6 +72,15 @@ public static class ActivationFunctionsGpu
                 device.For(outputs.Length, new CubeRootDerivativeKernel(outputBuffer, derivativeBuffer));
                 break;
         }
+
+    }
+
+    public static float[] Derivative(float[] outputs, ActivationKind kind)
+    {
+        using ReadOnlyBuffer<float> outputBuffer = GraphicsDevice.GetDefault().AllocateReadOnlyBuffer(outputs);
+        using ReadWriteBuffer<float> derivativeBuffer = GraphicsDevice.GetDefault().AllocateReadWriteBuffer<float>(outputs.Length);
+
+        Derivative(outputBuffer, derivativeBuffer, kind);
 
         return derivativeBuffer.ToArray();
     }

--- a/src/bnn/Gpu/InitialErrorsKernelRw.cs
+++ b/src/bnn/Gpu/InitialErrorsKernelRw.cs
@@ -1,0 +1,28 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct InitialErrorsKernelRw(
+    ReadWriteBuffer<float> cluster,
+    ReadWriteBuffer<float> finalErrors,
+    ReadWriteBuffer<float> hiddenDerivatives,
+    ReadWriteBuffer<float> initialErrors,
+    float trainingRate,
+    int outputs,
+    int stride) : IComputeShader
+{
+    public void Execute()
+    {
+        int h = ThreadIds.X;
+        float sum = 0f;
+
+        for (int o = 0; o < outputs; o++)
+        {
+            sum += finalErrors[o] * cluster[o * stride + h];
+        }
+
+        initialErrors[h] = sum * trainingRate * hiddenDerivatives[h];
+    }
+}

--- a/src/bnn/Gpu/KernelRw.cs
+++ b/src/bnn/Gpu/KernelRw.cs
@@ -1,0 +1,26 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct KernelRw(
+    ReadWriteBuffer<float> input,
+    ReadWriteBuffer<float> weights,
+    ReadWriteBuffer<float> output,
+    int inputSize,
+    int stride) : IComputeShader
+{
+    public void Execute()
+    {
+        int i = ThreadIds.X;
+        float sum = weights[i * stride + inputSize];
+
+        for (int j = 0; j < inputSize; j++)
+        {
+            sum += input[j] * weights[i * stride + j];
+        }
+
+        output[i] = sum;
+    }
+}

--- a/src/bnn/Gpu/UpdateWeightsKernelRw.cs
+++ b/src/bnn/Gpu/UpdateWeightsKernelRw.cs
@@ -1,0 +1,26 @@
+using ComputeSharp;
+
+namespace bnn.Gpu;
+
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
+[GeneratedComputeShaderDescriptor]
+internal readonly partial struct UpdateWeightsKernelRw(
+    ReadWriteBuffer<float> cluster,
+    ReadWriteBuffer<float> inputs,
+    ReadWriteBuffer<float> errors,
+    int inputSize,
+    int stride) : IComputeShader
+{
+    public void Execute()
+    {
+        int r = ThreadIds.X;
+        float err = errors[r];
+
+        for (int c = 0; c < inputSize; c++)
+        {
+            cluster[r * stride + c] += err * inputs[c];
+        }
+
+        cluster[r * stride + inputSize] += err;
+    }
+}

--- a/src/bnn/IBackPropagationNeuralNetwork.cs
+++ b/src/bnn/IBackPropagationNeuralNetwork.cs
@@ -1,0 +1,18 @@
+namespace bnn;
+
+using bnn.Data;
+using bnn.Gpu;
+
+public interface IBackPropagationNeuralNetwork
+{
+    TrainingReport BackPropagate(TrainingData trainingData,
+                                 double trainingRate,
+                                 int maxEpoch,
+                                 int seed);
+
+    double[] Predict(double[] inputLayer);
+
+    void SetActivationFunction(Func<double, double> activation,
+                               Func<double, double> activationDerivative,
+                               ActivationKind activationKind);
+}

--- a/src/bnn/Services/NeuronalNetworkTrainerService.cs
+++ b/src/bnn/Services/NeuronalNetworkTrainerService.cs
@@ -1,6 +1,7 @@
 ﻿using bnn.Data;
 using bnn.Options;
 using bnn.Gpu;
+using bnn;
 
 namespace bnn.Services;
 
@@ -16,7 +17,9 @@ internal sealed class NeuralNetworkTrainerService : INeuralNetworkTrainerService
                                                  ActivationKind activationKind,
                                                  CancellationToken cancellationToken = default)
     {
-        BackPropagationNeuralNetwork network = new(initialWeights, options.UseGpu);
+        IBackPropagationNeuralNetwork network = options.UseGpu
+            ? new BackPropagationNeuralNetworkGpu(initialWeights)
+            : new BackPropagationNeuralNetwork(initialWeights);
 
         network.SetActivationFunction(activation, activationDerivative, activationKind);
 


### PR DESCRIPTION
## Summary
- add overload to compute activation derivative on existing GPU buffers
- introduce new compute shaders to operate on ReadWriteBuffer data
- extend GpuBackpropagation to support persistent buffer training
- load network weights into GPU once in `BackPropagationNeuralNetworkGpu`
- compute predictions entirely on GPU using the new helpers

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e5e297b48333b5ed395df9a4f37f